### PR TITLE
ExecutorThreadPool: increase request queue size and increase corePoolSize

### DIFF
--- a/exhibitor-standalone/src/main/java/com/netflix/exhibitor/application/ExhibitorMain.java
+++ b/exhibitor-standalone/src/main/java/com/netflix/exhibitor/application/ExhibitorMain.java
@@ -168,12 +168,14 @@ public class ExhibitorMain implements Closeable
         // to limit the length of the queue. Requests arriving when
         // the queue is full will be refused.
         // See https://dcosjira.atlassian.net/browse/DCOS-558
-        final int maxQueueSize = 64;
+        final int maxQueueSize = 4096;
         LinkedBlockingQueue<Runnable> queue = new LinkedBlockingQueue<Runnable>(maxQueueSize);
-        final int minThreads = 10;
+        // corePoolSize needs to be much higher than the number of Acceptors
+        // See https://jira.mesosphere.com/browse/DCOS-14045
+        final int corePoolSize = 20;
         final int maxThreads = 100;
         final int maxIdleTime = 5;
-        ExecutorThreadPool threadPool = new ExecutorThreadPool(minThreads, maxThreads, maxIdleTime, TimeUnit.SECONDS, queue);
+        ExecutorThreadPool threadPool = new ExecutorThreadPool(corePoolSize, maxThreads, maxIdleTime, TimeUnit.SECONDS, queue);
         server.setThreadPool(threadPool);
 
         Context root = new Context(server, "/", Context.SESSIONS);


### PR DESCRIPTION
The Acceptor threads come from the same ExecutorThreadPool that requests are served with, which leads to severe contention when there are 8 Acceptor threads active and the ExecutorThreadPool doesn't want to grow the pool past the `corePoolSize`.

Why the thread pool is limited to the `corePoolSize` and does not want to grow to `maximumPoolSize` I don't know. We set the `corePoolSize` to 20 here and that seems to fix the problem. We also increase the requests queue size to 4096 to guard against network latency hiccups between exhibitor nodes causing the queue to spike temporarily.

Fixes https://jira.mesosphere.com/browse/DCOS-14045