### PR TITLE
Added PatternLayoutEscaped

### DIFF
--- a/exhibitor-core/src/main/java/com/netflix/exhibitor/core/utils/PatternLayoutEscaped.java
+++ b/exhibitor-core/src/main/java/com/netflix/exhibitor/core/utils/PatternLayoutEscaped.java
@@ -7,51 +7,50 @@ import org.apache.log4j.spi.LoggingEvent;
  * When loggin multiline messages to the journal(journald in this case)
  * only the first line is logged. Escaping \n solves the problem.
  */
-public class PatternLayoutEscaped extends PatternLayout {
+public class PatternLayoutEscaped extends PatternLayout
+{
 
-  public PatternLayoutEscaped(final String s) {
-    super(s);
-  }
+	public PatternLayoutEscaped(final String s)
+	{
+		super(s);
+	}
 
-  public PatternLayoutEscaped() {
-    super();
-  }
+	public PatternLayoutEscaped()
+	{
+		super();
+	}
 
-  @Override
-  public String format(final LoggingEvent event) {
-    if (event.getMessage() instanceof String) {
-      return super.format(appendStackTraceToEvent(event));
-    }
-    return super.format(event);
-  }
+	@Override
+	public String format(final LoggingEvent event)
+	{
+		if (event.getMessage() instanceof String)
+		{
+			return super.format(appendStackTraceToEvent(event));
+		}
+		return super.format(event);
+	}
 
-  /**
-   * Create a copy of event, but append a stack trace to the message (if it exists). Then it escapes
-   * the backslashes, tabs, newlines and quotes in its message as we are sending it as JSON and we
-   * don't want any corruption of the JSON object.
-   */
-  private LoggingEvent appendStackTraceToEvent(final LoggingEvent event) {
-    String message = event.getMessage().toString();
-    // If there is a stack trace available, print it out
-    if (event.getThrowableInformation() != null) {
-      final String[] s = event.getThrowableStrRep();
-      for (final String line : s) {
-        message += "\n" + line;
-      }
-    }
-    message = message
-        .replace("\\", "\\\\")
-        .replace("\n", "\\n")
-        .replace("\"", "\\\"")
-        .replace("\t", "\\t");
+	/**
+	 * Create a copy of event, but append a stack trace to the message (if it exists). Then it escapes
+	 * the backslashes, tabs, newlines and quotes in its message as we are sending it as JSON and we
+	 * don't want any corruption of the JSON object.
+	 */
+	private LoggingEvent appendStackTraceToEvent(final LoggingEvent event)
+	{
+		String message = event.getMessage().toString();
+		message = message
+			.replace("\\", "\\\\")
+			.replace("\n", "\\n")
+			.replace("\"", "\\\"")
+			.replace("\t", "\\t");
 
-    final Throwable throwable = event.getThrowableInformation() == null ? null
-        : event.getThrowableInformation().getThrowable();
-    return new LoggingEvent(event.getFQNOfLoggerClass(),
-        event.getLogger(),
-        event.getTimeStamp(),
-        event.getLevel(),
-        message,
-        throwable);
-  }
+		final Throwable throwable = event.getThrowableInformation() == null ? null
+				: event.getThrowableInformation().getThrowable();
+		return new LoggingEvent(event.getFQNOfLoggerClass(),
+			event.getLogger(),
+			event.getTimeStamp(),
+			event.getLevel(),
+			message,
+			throwable);
+	}
 }

--- a/exhibitor-core/src/main/java/com/netflix/exhibitor/core/utils/PatternLayoutEscaped.java
+++ b/exhibitor-core/src/main/java/com/netflix/exhibitor/core/utils/PatternLayoutEscaped.java
@@ -1,0 +1,57 @@
+package com.netflix.exhibitor.core.utils;
+
+import org.apache.log4j.PatternLayout;
+import org.apache.log4j.spi.LoggingEvent;
+
+/**
+ * When loggin multiline messages to the journal(journald in this case)
+ * only the first line is logged. Escaping \n solves the problem.
+ */
+public class PatternLayoutEscaped extends PatternLayout {
+
+  public PatternLayoutEscaped(final String s) {
+    super(s);
+  }
+
+  public PatternLayoutEscaped() {
+    super();
+  }
+
+  @Override
+  public String format(final LoggingEvent event) {
+    if (event.getMessage() instanceof String) {
+      return super.format(appendStackTraceToEvent(event));
+    }
+    return super.format(event);
+  }
+
+  /**
+   * Create a copy of event, but append a stack trace to the message (if it exists). Then it escapes
+   * the backslashes, tabs, newlines and quotes in its message as we are sending it as JSON and we
+   * don't want any corruption of the JSON object.
+   */
+  private LoggingEvent appendStackTraceToEvent(final LoggingEvent event) {
+    String message = event.getMessage().toString();
+    // If there is a stack trace available, print it out
+    if (event.getThrowableInformation() != null) {
+      final String[] s = event.getThrowableStrRep();
+      for (final String line : s) {
+        message += "\n" + line;
+      }
+    }
+    message = message
+        .replace("\\", "\\\\")
+        .replace("\n", "\\n")
+        .replace("\"", "\\\"")
+        .replace("\t", "\\t");
+
+    final Throwable throwable = event.getThrowableInformation() == null ? null
+        : event.getThrowableInformation().getThrowable();
+    return new LoggingEvent(event.getFQNOfLoggerClass(),
+        event.getLogger(),
+        event.getTimeStamp(),
+        event.getLevel(),
+        message,
+        throwable);
+  }
+}

--- a/exhibitor-core/src/test/java/com/netflix/exhibitor/core/utils/TestPatternLayoutEscaped.java
+++ b/exhibitor-core/src/test/java/com/netflix/exhibitor/core/utils/TestPatternLayoutEscaped.java
@@ -1,0 +1,65 @@
+package com.netflix.exhibitor.core.utils;
+
+import org.apache.log4j.PatternLayout;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.apache.log4j.spi.LoggingEvent;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Test output of PatternLayoutEscapedTest
+ * It should be escaping new lines, quotes, tabs and backslashes
+ * This is necessary when we are logging these messages out as JSON objects
+ */
+public class TestPatternLayoutEscaped
+{
+    private Logger logger = Logger.getLogger(this.getClass());
+    private PatternLayout layout = new PatternLayoutEscaped();
+
+    @BeforeMethod
+    public void setup()
+    {
+        layout.setConversionPattern("%m");
+    }
+
+    @Test
+    public void testNewLine()
+    {
+        LoggingEvent event = createMessageEvent("This message contains \n new lines");
+        Assert.assertTrue(layout.format(event).equals("This message contains \\n new lines"));
+    }
+
+    @Test
+    public void testQuote()
+    {
+        LoggingEvent event = createMessageEvent("This message contains \" quotes");
+        Assert.assertTrue(layout.format(event).equals("This message contains \\\" quotes"));
+    }
+
+    @Test
+    public void testTab()
+    {
+        LoggingEvent event = createMessageEvent("This message contains a tab \t");
+        Assert.assertTrue(layout.format(event).equals("This message contains a tab \\t"));
+    }
+
+    @Test
+    public void testBackSlash()
+    {
+        LoggingEvent event = createMessageEvent("This message contains a backslash \\");
+        Assert.assertTrue(layout.format(event).equals("This message contains a backslash \\\\"));
+    }
+
+    private LoggingEvent createMessageEvent(String message)
+    {
+        return new LoggingEvent(this.getClass().getCanonicalName(),
+        logger,
+        0,
+        Level.toLevel("INFO"),
+        message,
+        new Exception());
+    }
+}


### PR DESCRIPTION
The log4j.appender.journal.layout property needs to be set to PatternLayoutEscaped so that multiline messages can be logged by exhibitor.