### PR TITLE
Enable specifying the Endpoint Suffix in the azure connection string

### DIFF
--- a/exhibitor-core/src/main/java/com/netflix/exhibitor/core/azure/AzureClientImpl.java
+++ b/exhibitor-core/src/main/java/com/netflix/exhibitor/core/azure/AzureClientImpl.java
@@ -16,7 +16,8 @@ public class AzureClientImpl implements AzureClient {
         this.storageConnectionString =
             "DefaultEndpointsProtocol=http" +
             ";AccountName=" + credentials.getAccountName() +
-            ";AccountKey=" + credentials.getAccountKey();
+            ";AccountKey=" + credentials.getAccountKey() +
+            ";EndpointSuffix=" + credentials.getEndpointSuffix();
     }
 
     @Override

--- a/exhibitor-core/src/main/java/com/netflix/exhibitor/core/azure/AzureCredential.java
+++ b/exhibitor-core/src/main/java/com/netflix/exhibitor/core/azure/AzureCredential.java
@@ -3,4 +3,5 @@ package com.netflix.exhibitor.core.azure;
 public interface AzureCredential {
     public String getAccountName();
     public String getAccountKey();
+    public String getEndpointSuffix();
 }

--- a/exhibitor-core/src/main/java/com/netflix/exhibitor/core/azure/PropertyBasedAzureCredential.java
+++ b/exhibitor-core/src/main/java/com/netflix/exhibitor/core/azure/PropertyBasedAzureCredential.java
@@ -8,9 +8,11 @@ import java.util.Properties;
 public class PropertyBasedAzureCredential implements AzureCredential {
     private final String accountName;
     private final String accountKey;
+    private final String endpointSuffix;
 
     public static final String PROPERTY_AZURE_ACCOUNT_NAME = "com.netflix.exhibitor.azure.account-name";
     public static final String PROPERTY_AZURE_ACCOUNT_KEY = "com.netflix.exhibitor.azure.account-key";
+    public static final String PROPERTY_AZURE_ENDPOINT_SUFFIX = "com.netflix.exhibitor.azure.endpoint-suffix";
 
     public PropertyBasedAzureCredential(File propertiesFile) throws IOException
     {
@@ -21,6 +23,7 @@ public class PropertyBasedAzureCredential implements AzureCredential {
     {
         accountName = properties.getProperty(PROPERTY_AZURE_ACCOUNT_NAME);
         accountKey = properties.getProperty(PROPERTY_AZURE_ACCOUNT_KEY);
+        endpointSuffix = properties.getProperty(PROPERTY_AZURE_ENDPOINT_SUFFIX);
     }
 
     @Override
@@ -32,6 +35,15 @@ public class PropertyBasedAzureCredential implements AzureCredential {
     public String getAccountKey()
     {
         return accountKey;
+    }
+
+    public String getEndpointSuffix()
+    {
+        if (endpointSuffix == null)
+        {
+            return "core.windows.net";
+        }
+        return endpointSuffix;
     }
 
     private static Properties loadProperties(File propertiesFile) throws IOException


### PR DESCRIPTION
The EndpointSuffix of an azure storage connection string changes depending on the Azure environment. The suffix for public Azure clouds is core.windows.net (default). The suffix for Azure USGov cloud is core.usgovcloudapi.net. This change allows the client to use the EndpointSuffix specified in the azure configuration file.