### PR TITLE
Get master to a buildable and testable state

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,10 @@ ext.githubProjectName = rootProject.name // Change if github project name is not
 subprojects {
     apply plugin: 'nebula.netflixoss'
     apply plugin: 'java'
+    // Add the `maven` plugin to ensure that the `exhibitor-{core,standalone}`
+    // jars are installed into the local `.m2` Maven repository for discovery
+    // by the shadow jar build.
+    apply plugin: 'maven'
 
     group = "com.netflix.${githubProjectName}" // TEMPLATE: Set to organization of project
 

--- a/exhibitor-core/src/test/java/com/netflix/exhibitor/core/automanage/TestRemoteInstanceRequestClient.java
+++ b/exhibitor-core/src/test/java/com/netflix/exhibitor/core/automanage/TestRemoteInstanceRequestClient.java
@@ -55,7 +55,7 @@ public class TestRemoteInstanceRequestClient
 
     // Truststore content:
     // 1 Certificate, CN: Root, SA Names: {localhost}, Signed by: self, Valid until: August/2027
-    URL invalidTruststoreUrl = ClassLoader.getSystemResource("com/netflix/exhibitor/core/automanage/test-invalidTruststore");
+    URL invalidTruststoreUrl = ClassLoader.getSystemResource("com/netflix/exhibitor/core/automanage/test-invalidtruststore");
     String invalidTruststorePath = invalidTruststoreUrl.getPath();
     String invalidTruststorePassword = "password";
 

--- a/exhibitor-standalone/src/main/resources/buildscripts/standalone/gradle/build.gradle
+++ b/exhibitor-standalone/src/main/resources/buildscripts/standalone/gradle/build.gradle
@@ -31,6 +31,7 @@ jar {
 }
 
 shadowJar {
+    classifier = 'all'
     mergeServiceFiles()
 }
 


### PR DESCRIPTION
Changes to Exhibitor to allow `master` to be used by DC/OS.

https://github.com/dcos/dcos/pull/7310 demonstrates that DC/OS can be built with these changes.